### PR TITLE
Update static_variant.hpp

### DIFF
--- a/include/fc/static_variant.hpp
+++ b/include/fc/static_variant.hpp
@@ -382,5 +382,5 @@ struct visitor {
       s.visit( to_static_variant(ar[1]) );
    }
 
-  template<typename... T> struct get_typename<T...>  { static const char* name()   { return typeid(static_variant<T...>).name();   } };
+  template<typename... T> struct get_typename  { static const char* name()   { return typeid(static_variant<T...>).name();   } };
 } // namespace fc


### PR DESCRIPTION
fix compile error when building with gcc 7.2 on archlinux